### PR TITLE
[Go-jfigaro] [Andi Pangeran] - fail load configuration from resources

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ repositories {
 }
 
 group 'com.gojek'
-version '1.2.3'
+version '1.2.4'
 
 jar {
     exclude('local.properties')

--- a/src/main/java/com/gojek/Figaro.java
+++ b/src/main/java/com/gojek/Figaro.java
@@ -3,7 +3,7 @@ package com.gojek;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.FileNotFoundException;
+import java.io.IOException;
 import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
@@ -22,7 +22,7 @@ public class Figaro {
             try {
                 String yamlFileName = getYamlFileName();
                 configuration = new YamlConfiguration(appEnvironment, yamlFileName);
-            } catch (FileNotFoundException e) {
+            } catch (IOException e) {
                 logger.error("yaml configuration was not found", e);
                 e.printStackTrace();
                 return null;

--- a/src/main/java/com/gojek/YamlConfiguration.java
+++ b/src/main/java/com/gojek/YamlConfiguration.java
@@ -4,8 +4,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.yaml.snakeyaml.Yaml;
 
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
 import java.net.URL;
 import java.util.Map;
 import java.util.Objects;
@@ -17,13 +17,13 @@ class YamlConfiguration extends ApplicationConfiguration {
     private String env;
 
     @SuppressWarnings("unchecked")
-    YamlConfiguration(String env, String yamlFileName) throws FileNotFoundException {
+    YamlConfiguration(String env, String yamlFileName) throws IOException {
         this.env = env;
         logger.debug("loading resource {} for {}", yamlFileName, this.env);
         URL resource = getClass().getResource(yamlFileName);
         Yaml yaml = new Yaml();
-        FileInputStream fileInputStream = new FileInputStream(resource.getFile());
-        configuration = (Map<String, Object>) yaml.load(fileInputStream);
+        InputStream is = resource.openStream();
+        configuration = (Map<String, Object>) yaml.load(is);
 
     }
 

--- a/src/test/java/com/gojek/YamlConfigurationTest.java
+++ b/src/test/java/com/gojek/YamlConfigurationTest.java
@@ -6,7 +6,7 @@ import org.junit.runner.RunWith;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
-import java.io.FileNotFoundException;
+import java.io.IOException;
 
 import static org.junit.Assert.assertEquals;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
@@ -16,31 +16,31 @@ import static org.powermock.api.mockito.PowerMockito.when;
 @PrepareForTest({YamlConfiguration.class})
 public class YamlConfigurationTest {
     @Test
-    public void shouldLoadConfig() throws FileNotFoundException {
+    public void shouldLoadConfig() throws IOException {
         YamlConfiguration test = new YamlConfiguration("development", "/application-yaml-configuration-test.yml");
         assertEquals("foo", test.getValue("shouldLoadConfig"));
     }
 
     @Test
-    public void shouldLoadConfigBasedOnEnvironment() throws FileNotFoundException {
+    public void shouldLoadConfigBasedOnEnvironment() throws IOException {
         YamlConfiguration test = new YamlConfiguration("test", "/application-yaml-configuration-test.yml");
         assertEquals("bar", test.getValue("shouldLoadConfigBasedOnEnvironment"));
     }
 
     @Test
-    public void shouldUseDefaultConfiWhenSpecificValueIsNotSet() throws FileNotFoundException {
+    public void shouldUseDefaultConfiWhenSpecificValueIsNotSet() throws IOException {
         YamlConfiguration test = new YamlConfiguration("test", "/application-yaml-configuration-test.yml");
         assertEquals("defaultFoo", test.getValue("shouldUseDefaultConfiWhenSpecificValueIsNotSet"));
     }
 
     @Test
-    public void shouldUseDefaultConfigWhenSpecificEncironmentIsNotSet() throws FileNotFoundException {
+    public void shouldUseDefaultConfigWhenSpecificEncironmentIsNotSet() throws IOException {
         YamlConfiguration test = new YamlConfiguration("something", "/application-yaml-configuration-test.yml");
         assertEquals("defaultFoo", test.getValue("shouldUseDefaultConfiWhenSpecificValueIsNotSet"));
     }
 
     @Test
-    public void shouldAllowEnvironmentOverride() throws FileNotFoundException {
+    public void shouldAllowEnvironmentOverride() throws IOException {
         mockStatic(System.class);
         when(System.getenv("shouldUseDefaultConfiWhenSpecificValueIsNotSet")).thenReturn("envOverrideFoo");
         YamlConfiguration test = new YamlConfiguration("something", "/application-yaml-configuration-test.yml");


### PR DESCRIPTION
fail load configuration from jar resource on runtime..

detail : 
the idea is FileInputStream can't open file from resource as the path is not found..  the resource already have open stream implementation..